### PR TITLE
change config.py to bypass load_env from ci.yml

### DIFF
--- a/apps/backend/thudbot_core/config.py
+++ b/apps/backend/thudbot_core/config.py
@@ -65,7 +65,12 @@ def _set_redis_host(verbose: bool = False):
     print(f"🔧 DEBUG: is_in_docker()={is_in_docker()}, COMPOSE_MODE={compose_mode}, REDIS_HOST={REDIS_HOST}")
 
 # Load .env variables before accessing any of them
-load_env()
+if os.getenv("CI") != "true":
+    load_env(verbose=True)
+else:
+    print("🧪 CI detected — skipping load_env() in config.py")
+    # Still set Redis host for CI
+    _set_redis_host(verbose=True)
 
 # Maximum number of concurrent sessions allowed
 # Session limits to prevent memory exhaustion DoS; can override in .env

--- a/apps/backend/thudbot_core/config.py
+++ b/apps/backend/thudbot_core/config.py
@@ -64,7 +64,7 @@ def _set_redis_host(verbose: bool = False):
 
     print(f"🔧 DEBUG: is_in_docker()={is_in_docker()}, COMPOSE_MODE={compose_mode}, REDIS_HOST={REDIS_HOST}")
 
-# Load .env variables before accessing any of them
+# Load .env variables before accessing any of them but skip in CI
 if os.getenv("CI") != "true":
     load_env(verbose=True)
 else:


### PR DESCRIPTION
This change prevents `load_env()` from running during CI builds by checking the `CI` environment variable before invoking it in `config.py`.

Previously, the CI pipeline failed because some tests indirectly triggered `load_env()` at module import time, which required a `.env` file and API keys. This fix gates the call behind a simple check:
